### PR TITLE
Adding appendmodulecmakeargs to config.

### DIFF
--- a/jhbuild/config.py
+++ b/jhbuild/config.py
@@ -69,6 +69,7 @@ _known_keys = [ 'moduleset', 'modules', 'skip', 'tags', 'prefix',
                 'disable_Werror', 'xdg_cache_home', 'exit_on_error',
                 'jhhome', # liuhuan: custom path under which we put modulesets, build, install
                 'modulecmakeargs', # liuhuan: custom package specific cmakeargs
+                'appendmodulecmakeargs' # woody: custom package specific appendcmakeargs
               ]
 
 env_prepends = {}

--- a/jhbuild/modtypes/cmake.py
+++ b/jhbuild/modtypes/cmake.py
@@ -161,6 +161,9 @@ def parse_cmake(node, config, uri, repositories, default_repo):
     # liuhuan: override cmakeargs defined in xml if it is specified in .jhbuildrc
     if config.modulecmakeargs.has_key(instance.name):
         instance.cmakeargs = config.modulecmakeargs[instance.name]
+    # woody: option to append to cmakeargs defined in .modulesets
+    elif config.appendmodulecmakeargs.has_key(instance.name):
+        instance.cmakeargs += " " + config.appendmodulecmakeargs[instance.name]
     elif node.hasAttribute('cmakeargs'):
         instance.cmakeargs = node.getAttribute('cmakeargs')
     if node.hasAttribute('makeargs'):


### PR DESCRIPTION
It can be used to append to cmake args defined in .modulesets